### PR TITLE
fix: update dev blog page params for Next 15

### DIFF
--- a/src/app/dev-blog/[slug]/page.tsx
+++ b/src/app/dev-blog/[slug]/page.tsx
@@ -7,8 +7,13 @@ export async function generateStaticParams() {
   return posts.map(post => ({ slug: post.slug }));
 }
 
-export default async function DevBlogPostPage({ params }: { params: { slug: string } }) {
-  const { content, meta } = await getDevBlogPost(params.slug);
+export default async function DevBlogPostPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const { content, meta } = await getDevBlogPost(slug);
   const compiledMdx = await compileMdx(content);
 
   return (


### PR DESCRIPTION
## Summary
- adjust dev blog post page to use promised `params`

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6898ad6df5248325bbd8ba87f035838c