### PR TITLE
Apply blue matrix overlay globally

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import React from 'react';
-import MatrixRain from '@/components/organisms/MatrixRain';
 
 export default function BlogPage() {
   return (
-    <div className="min-h-screen bg-black text-white relative overflow-hidden">
-      <MatrixRain />
+    <div className="min-h-screen text-white relative overflow-hidden">
       <div className="relative z-10 min-h-screen flex items-center justify-center">
         <div className="max-w-2xl mx-auto px-6 text-center">
           <div className="bg-slate-800/30 backdrop-blur-sm rounded-lg p-12 border border-slate-800">

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import React from 'react';
-import MatrixRain from '@/components/organisms/MatrixRain';
 
 export default function ContactPage() {
   return (
     <div className="min-h-screen text-white relative overflow-hidden">
-      <MatrixRain />
       <div className="relative z-10 min-h-screen flex items-center justify-center">
         <div className="max-w-2xl mx-auto px-6 text-center">
           <div className="bg-slate-800/30 backdrop-blur-sm rounded-lg p-12 border border-slate-800">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,18 +32,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={`${inter.variable} ${jetbrainsMono.variable} antialiased site-bg relative`}>
-        {/* Matrix Rain Layer */}
-        <div className="absolute inset-0 z-5 pointer-events-none">
-          <MatrixRainGlobal />
-        </div>
-        {/* Gradient Overlay */}
-        <div
-          className="absolute inset-0 z-10 pointer-events-none"
-          style={{
-            background:
-              'linear-gradient(to bottom, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.4) 85%, rgba(0,0,0,0.2) 100%)',
-          }}
-        />
+        {/* Matrix Rain Layer with Overlay */}
+        <MatrixRainGlobal />
         {/* Main Content */}
         <div className="relative z-20">
           <ThemeProvider>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import React from 'react';
-import MatrixRain from '@/components/organisms/MatrixRain';
 
 export default function ProjectsPage() {
   return (
-    <div className="min-h-screena text-white relative overflow-hidden">
-      <MatrixRain />
+    <div className="min-h-screen text-white relative overflow-hidden">
       <div className="relative z-10 min-h-screen flex items-center justify-center">
         <div className="max-w-2xl mx-auto px-6 text-center">
           <div className="bg-slate-800/30 backdrop-blur-sm rounded-lg p-12 border border-slate-800">

--- a/src/components/organisms/MatrixRainGlobal.tsx
+++ b/src/components/organisms/MatrixRainGlobal.tsx
@@ -11,6 +11,13 @@ export default function MatrixRainGlobal() {
   return (
     <div className="absolute inset-0 z-5 pointer-events-none">
       <MatrixRain />
+      <div
+        className="absolute inset-0 z-10"
+        style={{
+          background:
+            'linear-gradient(to bottom, rgba(30,58,138,0.45) 0%, rgba(23,37,84,0.45) 85%, rgba(15,23,42,0.3) 100%)',
+        }}
+      />
     </div>
   );
 }

--- a/src/components/pages/LandingPage.tsx
+++ b/src/components/pages/LandingPage.tsx
@@ -1,25 +1,9 @@
-import dynamic from 'next/dynamic';
 import HeroSection from '@/components/organisms/HeroSection';
-
-const MatrixRain = dynamic(() => import('@/components/organisms/MatrixRain'), {
-  ssr: false,
-  loading: () => null,
-});
 
 export default function LandingPage() {
   return (
     <div className="relative h-full w-full">
-      <MatrixRain />
-
-      <div
-        className="absolute inset-0 z-10 pointer-events-none"
-        style={{
-          background:
-            'linear-gradient(to bottom, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.4) 85%, rgba(0,0,0,0.2) 100%)',
-        }}
-      />
-
-      <div className="absolute inset-0 z-20 flex flex-col items-center justify-center px-6 text-center">
+      <div className="absolute inset-0 flex flex-col items-center justify-center px-6 text-center">
         <HeroSection
           name="Donald Jennings"
           summary="Software Engineer at Leonardo UK Ltd | MIET | BSc (Hons) Computer Science"


### PR DESCRIPTION
## Summary
- Add reusable MatrixRainGlobal overlay with blue gradient
- Use global matrix overlay from layout and drop per-page MatrixRain instances

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898b08299ec8325a849edc111da2d9d