### PR TITLE
Fix Netlify deploy failure caused by Google font fetch during build

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,21 +6,9 @@ import NavBar from '@/components/organisms/NavBar';
 import { ThemeProvider } from '@/components/context/ThemeContext';
 import '../styles/mdx.css';
 
-import { Inter, JetBrains_Mono } from 'next/font/google';
-
 import MatrixRainGlobal from '@/components/organisms/MatrixRainGlobal';
 import RadialGradientOverlay from '@/components/atoms/RadialGradientOverlay';
 import { Analytics } from '@vercel/analytics/next';
-
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
-});
-
-const jetbrainsMono = JetBrains_Mono({
-  subsets: ['latin'],
-  variable: '--font-jetbrains-mono',
-});
 
 export const metadata: Metadata = {
   title: 'Donald Jennings - Portfolio',
@@ -34,7 +22,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body
-        className={`${inter.variable} ${jetbrainsMono.variable} antialiased site-bg relative`}
+        className="antialiased site-bg relative"
         style={{
           background: 'linear-gradient(to bottom, #0f172a 0%, #1e293b 60%, #0a192f 100%)',
         }}


### PR DESCRIPTION
### Motivation
- Netlify builds were failing because Next.js attempted to download Google Fonts (`Inter` and `JetBrains Mono`) at build time, creating a network dependency that caused `next build` to fail on deploy.

### Description
- Removed the `next/font/google` import and font variable usage from `src/app/layout.tsx`, and stopped adding those font variables to the `<body>` class while keeping the existing CSS font fallbacks in `globals.css`.

### Testing
- Ran `npm run build` which completed successfully, and `npm run lint` which reported no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5233b56548325948dec5a02bf34ca)