### PR TITLE
Fix blog/projects rendering: remove MDX compile and unnecessary force-dynamic

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,12 +1,9 @@
 import { notFound } from 'next/navigation';
 import ContentPostPage from '@/components/pages/ContentPostPage';
 import { getDevBlogPost, getDevBlogPosts } from '@/lib/devblog';
-import { compileMdx } from '@/lib/compileMDX';
-
-export const dynamic = 'force-dynamic';
 
 export async function generateStaticParams() {
-  const posts = await getDevBlogPosts();
+  const posts = getDevBlogPosts();
   return posts.map(post => ({ slug: post.slug }));
 }
 
@@ -15,7 +12,6 @@ export default async function DevBlogPostPage({ params }: { params: Promise<{ sl
   const post = getDevBlogPost(slug);
   if (!post) notFound();
   const { content, meta } = post;
-  const compiledMdx = await compileMdx(content);
 
   const metaWithParent = {
     ...meta,
@@ -28,7 +24,7 @@ export default async function DevBlogPostPage({ params }: { params: Promise<{ sl
 
   return (
     <div className="min-h-screen relative">
-      <ContentPostPage meta={metaWithParent}>{compiledMdx}</ContentPostPage>
+      <ContentPostPage meta={metaWithParent}>{content}</ContentPostPage>
     </div>
   );
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,7 +1,5 @@
 import BlogLandingPage from '@/components/pages/BlogLandingPage';
 
-export const dynamic = 'force-dynamic';
-
 export default async function BlogPage() {
   return <BlogLandingPage />;
 }

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,9 +1,6 @@
 import { notFound } from 'next/navigation';
 import ContentPostPage from '@/components/pages/ContentPostPage';
 import { getAllProjects, getProject, ProjectMeta } from '@/lib/projects';
-import { compileMdx } from '@/lib/compileMDX';
-
-export const dynamic = 'force-dynamic';
 
 export async function generateStaticParams() {
   const projects = getAllProjects();
@@ -15,7 +12,6 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
   const project = getProject(slug);
   if (!project) notFound();
   const { content, meta } = project;
-  const compiledMdx = await compileMdx(content);
 
   const metaWithParent = {
     ...meta,
@@ -30,7 +26,7 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
 
   return (
     <div className="min-h-screen relative">
-      <ContentPostPage meta={metaWithParent}>{compiledMdx}</ContentPostPage>
+      <ContentPostPage meta={metaWithParent}>{content}</ContentPostPage>
     </div>
   );
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import ProjectsLandingPage from '../../components/pages/ProjectsLandingPage';
 
-export const dynamic = 'force-dynamic';
-
 export default function ProjectsPage() {
   return <ProjectsLandingPage />;
 }


### PR DESCRIPTION
### Motivation
- Pages were still attempting to compile MDX after MDX parsing was removed, causing slow renders and 500 errors for content fetched from the content stores. 
- Several pages were forced into dynamic rendering with `export const dynamic = 'force-dynamic'`, introducing avoidable runtime overhead when content can be rendered from the in-memory/store values.

### Description
- Removed `compileMdx` import and its invocation from the blog and project slug pages so the stored `content` string is passed directly into `ContentPostPage` (`src/app/blog/[slug]/page.tsx`, `src/app/projects/[slug]/page.tsx`).
- Removed `export const dynamic = 'force-dynamic'` from blog and projects list and detail pages to avoid unnecessary dynamic rendering (`src/app/blog/page.tsx`, `src/app/projects/page.tsx`, and the slug pages). 
- Simplified `generateStaticParams` in the blog slug page to call `getDevBlogPosts()` synchronously to match the content-store helper pattern.
- Updated routing/content flow so detail pages no longer depend on the removed MDX compilation code path.

### Testing
- Attempted production build with `npm run build` which failed due to environment font fetch issues in the `next/font` Google Fonts pipeline (network fetch of Google Fonts blocked), not because of the content changes. 
- Lint run with `npm run lint` failed in this environment with `Invalid project directory provided, no such directory: /workspace/portfolio-website/lint` and is unrelated to the functional fix.
- Ran the dev server and confirmed HTTP 200 for detail pages using `curl` against `/blog/faasm-funclets` and `/projects/faasm-load-balancer`, both returning 200. 
- Automated browser checks with Playwright verified navigation: clicking the top-nav `Developer Blog` and `Projects` links navigates to `/blog` and `/projects` respectively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b83dd9501483258096e7eddb142deb)